### PR TITLE
fix(ci): Correct path to requirements.txt in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r screenshot_tool/requirements.txt
       # IMPORTANT NOTE for cross-platform builds:
       # On different OS runners (especially Linux), additional dependencies might be needed for GUI libraries and Tesseract OCR.
       # For example, on Linux, you might need:


### PR DESCRIPTION
The GitHub Actions workflow was failing to install Python dependencies because the `pip install -r requirements.txt` command was executed from the repository root, while the `requirements.txt` file is located at `screenshot_tool/requirements.txt`.

This commit updates the `Install Dependencies` step in `.github/workflows/main.yml` to use the correct path: `pip install -r screenshot_tool/requirements.txt`.